### PR TITLE
Initial version of readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,113 @@
+Generate and load Pandas data frames based on JSON Table Schema descriptors.
+
+Quick start
+===========
+
+You can easily load resources from a data package as Pandas data frames by
+simply using ``datapackage.push_datapackage`` function:
+
+.. code-block:: python
+
+    >>> import datapackage
+
+    >>> data_url = 'http://data.okfn.org/data/core/country-list/datapackage.json'
+    >>> storage = datapackage.push_datapackage(data_url, 'pandas')
+
+    >>> storage.tables
+    ['data___data']
+
+    >>> type(storage['data___data'])
+    <class 'pandas.core.frame.DataFrame'>
+
+    >>> storage['data___data'].head()
+                 Name Code
+    0     Afghanistan   AF
+    1   Åland Islands   AX
+    2         Albania   AL
+    3         Algeria   DZ
+    4  American Samoa   AS
+
+Also it is possible to pull your existing data frame into a data package:
+
+.. code-block:: python
+
+    >>> datapackage.pull_datapackage('/tmp/datapackage.json', 'country_list', 'pandas', tables={
+    ...     'data': storage['data___data'],
+    ... })
+    Storage
+
+Tabular Storage
+===============
+
+Package implements `Tabular Storage`_ interface.
+
+We can get storage this way:
+
+.. code-block:: python
+
+    >>> from jsontableschema_pandas import Storage
+
+    >>> storage = Storage()
+
+Storage works as a container for Pandas data frames. You can define new data
+frame inside storage using ``storage.create`` method:
+
+.. code-block:: python
+
+    >>> storage.create('data', {
+    ...     'primaryKey': 'id',
+    ...     'fields': [
+    ...         {'name': 'id', 'type': 'integer'},
+    ...         {'name': 'comment', 'type': 'string'},
+    ...     ]
+    ... })
+
+    >>> storage.tables
+    ['data']
+
+    >>> storage['data'].shape
+    (0, 0)
+
+Use ``storage.write`` to populate data frame with data:
+
+.. code-block:: python
+
+    >>> storage.write('data', [(1, 'a'), (2, 'b')])
+
+    >>> storage['data']
+       comment
+    id        
+    1        a
+    2        b
+
+Also you can use tabulator_ to populate data frame from external data file:
+
+.. code-block:: python
+
+    >>> import tabulator
+
+    >>> with tabulator.topen('data/comments.csv', with_headers=True) as data:
+    ...     storage.write('data', data)
+
+    >>> storage['data']
+       comment
+    id        
+    1        a
+    2        b
+    1     good
+
+As you see, subsequent writes simply appends new data on top of existing ones.
+
+
+Contributing
+============
+
+Please read the contributing guideline:
+
+`How to Contribute <https://github.com/frictionlessdata/jsontableschema-sql-py/blob/master/CONTRIBUTING.md>`_
+
+Thanks!
+
+
+.. _Tabular Storage: https://github.com/okfn/datapackage-storage-py#tabular-storage
+.. _tabulator: https://github.com/frictionlessdata/tabulator-py


### PR DESCRIPTION
English is my second language so it is quite possible that readme can sound as would be written in a broken English.

Added `README.rst` instead of `README.md` because pypi.python.org does not support `.md`, see for yourself: https://pypi.python.org/pypi/jsontableschema

All code in `README.rst` can be tested with `py.test --doctest-modules README.rst` and currently all tests pass. Not sure if it worth adding it to tox?

Depends on: https://github.com/frictionlessdata/datapackage-py/pull/85
See also: https://github.com/frictionlessdata/jsontableschema-pandas-py/issues/2#issuecomment-219679832
