### PR TITLE
Relaxed under v1 dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,9 @@ PACKAGE = 'jsontableschema_pandas'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
     'six>=1.9,<2.0a',
-    'pandas>=0.18,<0.19a',
-    'tabulator>=0.7,<0.8a',
-    'jsontableschema>=0.7,<0.8a',
+    'pandas>=0.18,<1.0a',
+    'tabulator>=0.7,<1.0a',
+    'jsontableschema>=0.7,<1.0a',
 ]
 TESTS_REQUIRE = [
     'pylama',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ PACKAGE = 'jsontableschema_pandas'
 NAME = PACKAGE.replace('_', '-')
 INSTALL_REQUIRES = [
     'six>=1.9,<2.0a',
-    'pandas>=0.18,<1.0a',
+    # pandas 0.19 hangs on install
+    'pandas>=0.18,<0.19a',
     'tabulator>=0.7,<1.0a',
     'jsontableschema>=0.7,<1.0a',
 ]


### PR DESCRIPTION
# Overview

Dependencies under `v1` are now limited by `<1.0a` for more flexibility.
